### PR TITLE
update position after changing velocity in add force

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use std::f32::consts::PI;
 
 pub mod particle;
 
+const COUNT: usize = 200;
+const CLASSES_COUNT: usize = 8;
 
 fn window_conf() -> Conf {
     Conf {
@@ -32,10 +34,6 @@ fn init(particles: &mut [particle::Particle], particle_classes: &mut [particle::
 async fn main() {
     rand::srand(macroquad::miniquad::date::now() as _);
 
-    const COUNT: usize = 2000;
-    const CLASSES_COUNT: usize = 8;
-
-
     let mut particles = [Particle::new(Vec2::new(0.0,0.0), Vec2::new(0.0, 0.0), ParticleClass::new()); COUNT];
     let mut particle_classes = [ParticleClass::new(); CLASSES_COUNT];
 
@@ -57,10 +55,6 @@ async fn main() {
         }
 
         for i in 0..particles.len() {
-            particles[i].update();
-        }
-
-        for i in 0..particles.len() {
             let particle1 = &mut particles[i].clone();
 
             for j in 0..particles.len() {
@@ -70,6 +64,10 @@ async fn main() {
                     particle2.resolve_collision(particle1);
                 }
             }
+        }
+
+        for i in 0..particles.len() {
+            particles[i].update();
         }
 
         for i in 0..particles.len() {

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -1,6 +1,6 @@
 use macroquad::{prelude::*, window};
 
-const RADIUS: f32 = 5.0;
+const RADIUS: f32 = 20.0;
 const FRICTION: f32 = 0.5;
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Hi, 

I checked the code and aware the following situation where 
the main loop has functions executed in the following sequence
  ...
  `add_force()` changes velocity
  **`update()` changes position based on velocity from only `add_force()`** 
  `resolve_collision()` changes velocity
  `draw()` draw particle based on updated position
  ...

suggestion
  ...
  `add_force()` changes velocity
  `resolve_collision()` changes velocity
  **`update()` changes position based on new velocity from `add_force()`  and `resolve_collision()`**
  `draw()` draw particles based updated position
  ...
  
This happens to remove jiggles for solo particles, but in situation when one particle has two/more particles nearby, it seems to be undecisive, either to attract or to repel. Suggesting that a delay mechanism or level of attraction/repel is implemented. What works~ chill

-w-